### PR TITLE
fixup in self-hosted argument parsing

### DIFF
--- a/src-self-hosted/arg.zig
+++ b/src-self-hosted/arg.zig
@@ -10,7 +10,7 @@ const HashMap = std.HashMap;
 fn trimStart(slice: []const u8, ch: u8) []const u8 {
     var i: usize = 0;
     for (slice) |b| {
-        if (b != '-') break;
+        if (b != ch) break;
         i += 1;
     }
 


### PR DESCRIPTION
Not a bug as trimStart is currently only used for trimming '-'. Stumbled upon this while reading up on argument parsing and thought I'd send you a PR.